### PR TITLE
Update tab-example.php

### DIFF
--- a/site/blueprints/tab-example.php
+++ b/site/blueprints/tab-example.php
@@ -37,11 +37,11 @@ fields:
     type: tab
     icon: image
 
-  title_slider:
+  titleSlider:
     label: Title
     type: text
 
-  text_slider:
+  textSlider:
     label: Text
     type: text
 
@@ -55,11 +55,11 @@ fields:
     type: tab
     icon: diamond
 
-  title_features:
+  titleFeatures:
     label: Title
     type: text
 
-  text_features:
+  textFeatures:
     label: Text
     type: text
 
@@ -73,11 +73,11 @@ fields:
     type: tab
     icon: random
 
-  title_workflow:
+  titleWorkflow:
     label: Title
     type: text
 
-  text_workflow:
+  textWorkflow:
     label: Text
     type: text
 
@@ -91,10 +91,10 @@ fields:
     type: tab
     icon: quote-right
 
-  title_quotes:
+  titleQuotes:
     label: Title
     type: text
 
-  text_quotes:
+  textQuotes:
     label: Text
     type: text


### PR DESCRIPTION
Changed the field names to camel case without underscores. If I used underscores for the field names, I had problems accessing them in the templates because my PHP environment doesn't accept things like

`
<?php echo $page->title-Quotes() ?>
`

Kirby saves the fields with underscore like this:

` title_quotes -----> title-quotes
       yml                          txt`